### PR TITLE
Fix the problem that getHeight() is smaller than the actual value

### DIFF
--- a/poi/src/main/java/org/apache/poi/sl/draw/DrawTextFragment.java
+++ b/poi/src/main/java/org/apache/poi/sl/draw/DrawTextFragment.java
@@ -89,7 +89,7 @@ public class DrawTextFragment implements Drawable  {
      * @return full height of this text run which is sum of ascent, descent and leading
      */
     public float getHeight(){
-        double h = layout.getAscent() + layout.getDescent();
+        double h = layout.getAscent() + layout.getDescent() + getLeading();
         return (float)h;
     }
 


### PR DESCRIPTION
`+ getLeading()` was removed in this commit: https://github.com/apache/poi/commit/5a18307eb051603509c8b8147f4dfdf0e8fe56b2#diff-4cd687c3da36fff3b21d074a27f7bac176c2845b43d37eca3af37fb920baf32cL73 I can't find a reason for the removal.
Due to the lack of leading height, the height obtained by this method is much smaller than the actual height (Test with Chinese characters).